### PR TITLE
Fix meta tag and time logic bugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Only one viewport tag is required; duplicate removed for consistent responsive behavior -->
     <title>Kompensasjonskalkulator – Beregn lønn for vakter og ekstratimer | kkarlsen.art</title>
     <meta name="description" content="Få kontroll på lønna. Kalkuler vaktlønn, tillegg og kompensasjon automatisk. Enten du jobber helg, kveld eller tar ekstravakter. Gratis og presist.">
     <link rel="stylesheet" href="css/main.css">
-    <meta name="viewport" content="height=device-height, width=device-width, initial-scale=1.0">
     <link rel="icon" href="/assets/favicon.ico" type="image/x-icon">
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
     <script src="js/animations.js" defer></script>


### PR DESCRIPTION
## Summary
- add comment about single viewport meta tag
- limit shift hour options to 06–23 with comment
- clarify midnight handling in calculateShift and bonus logic

## Testing
- `tidy -q -e index.html`
- `tidy -q -e kalkulator/index.html`
- `tidy -q -e kalkulator/app.html`


------
https://chatgpt.com/codex/tasks/task_e_68447dcf8418832f8864a911a5d578a6